### PR TITLE
Increase timeout to 10 minutes

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
@@ -45,6 +46,8 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 	if err != nil {
 		return nil, fmt.Errorf("http client options: %w", err)
 	}
+
+	opts.Timeouts.Timeout = 10 * time.Minute
 
 	client, err := httpclient.New(opts)
 	if err != nil {


### PR DESCRIPTION
Grafana sets the default HTTP client timeout to 30 seconds, which is way to low for our kind of queries. I increased to 10 minutes.