### PR TITLE
Accept custom database names in query editor

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -94,7 +94,8 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
                     onChange={onDatabaseChange}
                     value={ databaseRef ? { label: databaseRef.current!, value: databaseRef.current! } : undefined }
                     isClearable
-                    isSearchable={false}
+                    isSearchable={true}
+                    allowCustomValue={true}
                 />
             </InlineField>
             <SQLEditor


### PR DESCRIPTION
This allows to query custom data uploaded to the playground. The `/databases` endpoint does only report the hardcoded `demo` database (by design) and is not aware of the custom ones.