### PR TITLE
plugin.json: allow forwards-compatibility

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -32,7 +32,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": "^9.3.8",
+    "grafanaDependency": ">=9.3.8",
     "plugins": []
   }
 }


### PR DESCRIPTION
Grafana Cloud is on 10.x
![Screenshot 2023-06-08 7 55 37 AM](https://github.com/SnellerInc/grafana-datasource/assets/2940902/a9472373-5a61-402c-a81a-245e0afd1ed6)
![Screenshot 2023-06-08 7 55 22 AM](https://github.com/SnellerInc/grafana-datasource/assets/2940902/8434d063-0e50-4a55-b69c-0b1288296948)
