### PR TITLE
remove html comment from readme

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,5 +1,3 @@
-<!-- This README file is going to be the one displayed on the Grafana.com website -->
-
 # Sneller Grafana Data Source
 
 ## Introduction


### PR DESCRIPTION
This HTML comment is rendered on the Grafana homepage:
![Screenshot 2023-06-08 8 50 29 AM](https://github.com/SnellerInc/grafana-datasource/assets/2940902/215fbae9-a417-454e-95ff-e486f9cfe240)
