### PR TITLE
Add support for client side variable interpolation

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,7 +1,7 @@
-import { DataSourceInstanceSettings, CoreApp } from '@grafana/data';
-import { DataSourceWithBackend } from '@grafana/runtime';
+import { CoreApp, DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
+import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 
-import { SnellerQuery, SnellerDataSourceOptions, DEFAULT_QUERY } from './types';
+import { DEFAULT_QUERY, SnellerDataSourceOptions, SnellerQuery } from './types';
 import { SnellerVariableSupport } from "./variables";
 
 export class DataSource extends DataSourceWithBackend<SnellerQuery, SnellerDataSourceOptions> {
@@ -12,5 +12,13 @@ export class DataSource extends DataSourceWithBackend<SnellerQuery, SnellerDataS
 
   getDefaultQuery(_: CoreApp): Partial<SnellerQuery> {
     return DEFAULT_QUERY
+  }
+
+  applyTemplateVariables(query: SnellerQuery, scopedVars: ScopedVars): Record<string, any> {
+    console.log(query.sql)
+    return {
+      ...query,
+      sql: getTemplateSrv().replace(query.sql, scopedVars),
+    };
   }
 }


### PR DESCRIPTION
Closes #13

> **Note**: 
> Because variables can only be interpolated in the browser, be aware that any alerting queries that contain template variables can result in undefined behavior.

The default variables like `$__from` are interpolated by this frontend function as well, but as this won't work for background queries (like for the mentioned alerting functionality), I kept the backend interpolation code in addition.