### PR TITLE
Add `$__timeGroup(x)` macro

### DIFF
--- a/pkg/plugin/macros.go
+++ b/pkg/plugin/macros.go
@@ -75,6 +75,8 @@ func (m *snellerMacroEngine) Interpolate(query backend.DataQuery, sql string) st
 		case "timeFilter":
 			// See https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#timefilter-or-__timefilter
 			return fmt.Sprintf("%s BETWEEN `%s` AND `%s`", groups[2], query.TimeRange.From.Format(time.RFC3339), query.TimeRange.To.Format(time.RFC3339))
+		case "timeGroup":
+			return m.Interpolate(query, fmt.Sprintf("DATE_BIN('$__interval_ms milliseconds', %s, `${from:date:iso}`)", groups[2]))
 		}
 		return groups[0]
 	})

--- a/pkg/plugin/macros.go
+++ b/pkg/plugin/macros.go
@@ -76,7 +76,7 @@ func (m *snellerMacroEngine) Interpolate(query backend.DataQuery, sql string) st
 			// See https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#timefilter-or-__timefilter
 			return fmt.Sprintf("%s BETWEEN `%s` AND `%s`", groups[2], query.TimeRange.From.Format(time.RFC3339), query.TimeRange.To.Format(time.RFC3339))
 		case "timeGroup":
-			return m.Interpolate(query, fmt.Sprintf("DATE_BIN('$__interval_ms milliseconds', %s, `${from:date:iso}`)", groups[2]))
+			return m.Interpolate(query, fmt.Sprintf("DATE_BIN('$__interval_ms milliseconds', %s, `${__from:date:iso}`)", groups[2]))
 		}
 		return groups[0]
 	})

--- a/src/README.md
+++ b/src/README.md
@@ -83,6 +83,10 @@ The maximum amount of data points that can be visualized by the graph. You can u
 
 This helper macro translates to `field BETWEEN $__from AND $__to` and can be used for convenient input range restriction.
 
+### `$__timeGroup(field)`
+
+This helper macro translates to ``DATE_BIN('$__interval_ms milliseconds', field, `${from:date:iso}`)`` and can be used for convenient time bucket grouping.
+
 ### `$__time(field)`
 
 A time field is required for time series charts. In some cases, these values are not stored as `timestamp` data or calculated on demand. Use this macro to mark a specific field as a "time" field. The data source will attempt to convert these values to `timestamp`s as needed. Currently numeric values in UNIX millisecond timestamp format and strings in RFC3339 format are supported.

--- a/src/README.md
+++ b/src/README.md
@@ -85,7 +85,7 @@ This helper macro translates to `field BETWEEN $__from AND $__to` and can be use
 
 ### `$__timeGroup(field)`
 
-This helper macro translates to ``DATE_BIN('$__interval_ms milliseconds', field, `${from:date:iso}`)`` and can be used for convenient time bucket grouping.
+This helper macro translates to ``DATE_BIN('$__interval_ms milliseconds', field, `${__from:date:iso}`)`` and can be used for convenient time bucket grouping.
 
 ### `$__time(field)`
 


### PR DESCRIPTION
This PR adds the `$__timeGroup(x)` macro to simplify a very common usecase:

```sql
$__timeGroup(x) -> DATE_BIN('$__interval_ms milliseconds', x, `${__from:date:iso}`)
```